### PR TITLE
Fix time filter and slider interaction

### DIFF
--- a/script.js
+++ b/script.js
@@ -548,6 +548,9 @@ document.getElementById('timeSliderStart').addEventListener('input', function() 
     this.value = endValue;
   }
 
+// Reset period filter when sliders are manually adjusted
+  document.getElementById('periodFilter').value = 'all';
+  
   updateVisualisations();
 });
 
@@ -560,6 +563,9 @@ document.getElementById('timeSliderEnd').addEventListener('input', function() {
     this.value = startValue;
   }
 
+// Reset period filter when sliders are manually adjusted
+  document.getElementById('periodFilter').value = 'all';
+  
   updateVisualisations();
 });
 


### PR DESCRIPTION
This PR addresses two issues with the time filters:
1. When sliders are manually adjusted, the period filter now resets to "All Periods"
2. When "All Periods" is selected, the sliders reset to the full date range